### PR TITLE
Add support for CRC checks on received data

### DIFF
--- a/huanyang.c
+++ b/huanyang.c
@@ -87,6 +87,7 @@ static void spindleSetRPM (float rpm, bool block)
 
         modbus_message_t rpm_cmd = {
             .context = (void *)VFD_SetRPM,
+            .crc_check = false,
             .adu[0] = VFD_ADDRESS,
             .adu[1] = ModBus_WriteRegister,
             .adu[2] = 0x10,
@@ -102,6 +103,7 @@ static void spindleSetRPM (float rpm, bool block)
 
         modbus_message_t rpm_cmd = {
             .context = (void *)VFD_SetRPM,
+            .crc_check = false,
             .adu[0] = VFD_ADDRESS,
             .adu[1] = ModBus_WriteCoil,
             .adu[2] = 0x02,
@@ -137,6 +139,7 @@ static void spindleSetState (spindle_state_t state, float rpm)
 
     modbus_message_t mode_cmd = {
         .context = (void *)VFD_SetStatus,
+        .crc_check = false,
         .adu[0] = VFD_ADDRESS,
         .adu[1] = ModBus_WriteRegister,
         .adu[2] = 0x20,
@@ -149,6 +152,7 @@ static void spindleSetState (spindle_state_t state, float rpm)
 
     modbus_message_t mode_cmd = {
         .context = (void *)VFD_SetStatus,
+        .crc_check = false,
         .adu[0] = VFD_ADDRESS,
         .adu[1] = ModBus_ReadHoldingRegisters,
         .adu[2] = 0x01,
@@ -177,6 +181,7 @@ static spindle_state_t spindleGetState (void)
 
     modbus_message_t mode_cmd = {
         .context = (void *)VFD_GetRPM,
+        .crc_check = false,
         .adu[0] = VFD_ADDRESS,
         .adu[1] = ModBus_ReadHoldingRegisters,
         .adu[2] = 0x70,
@@ -191,6 +196,7 @@ static spindle_state_t spindleGetState (void)
 
     modbus_message_t mode_cmd = {
         .context = (void *)VFD_GetRPM,
+        .crc_check = false,
         .adu[0] = VFD_ADDRESS,
         .adu[1] = ModBus_ReadInputRegisters,
         .adu[2] = 0x03,
@@ -311,6 +317,7 @@ static void huanyang_settings_changed (settings_t *settings)
 
             modbus_message_t cmd = {
                 .context = (void *)VFD_GetMaxRPM,
+                .crc_check = false,
                 .adu[0] = VFD_ADDRESS,
                 .adu[1] = ModBus_ReadHoldingRegisters,
                 .adu[2] = 0xB0,
@@ -328,6 +335,7 @@ static void huanyang_settings_changed (settings_t *settings)
 
             modbus_message_t cmd = {
                 .context = (void *)VFD_GetMaxRPM50,
+                .crc_check = false,
                 .adu[0] = VFD_ADDRESS,
                 .adu[1] = ModBus_ReadCoils,
                 .adu[2] = 0x03,

--- a/modbus.h
+++ b/modbus.h
@@ -53,6 +53,7 @@ typedef enum {
 
 typedef struct {
     void *context;
+    bool crc_check;
     uint8_t tx_length;
     uint8_t rx_length;
     char adu[MODBUS_MAX_ADU_SIZE];

--- a/modbus.h
+++ b/modbus.h
@@ -45,7 +45,10 @@ typedef enum {
     ModBus_WriteCoil = 5,
     ModBus_WriteRegister = 6,
     ModBus_ReadExceptionStatus = 7,
-    ModBus_Diagnostics = 8
+    ModBus_Diagnostics = 8,
+    ModBus_WriteCoils = 15,
+    ModBus_WriteRegisters = 16
+
 } modbus_function_t;
 
 typedef struct {


### PR DESCRIPTION
Add support for CRC checks on the received modbus packets, but leaving checks disabled on the Huanyang spindle plugin (as the Huanyang protocol is not quite compliant). 

Also adds a couple more modbus command definitions for future use.