### PR TITLE
Spindle load updates

### DIFF
--- a/vfd/spindle.c
+++ b/vfd/spindle.c
@@ -204,6 +204,11 @@ static bool vfd_spindle_select (spindle_id_t spindle_id)
     return true;
 }
 
+const vfd_ptrs_t *vfd_get_active (void)
+{
+    return &vfd_spindle;
+}
+
 void vfd_init (void)
 {
     if(modbus_enabled() && (nvs_address = nvs_alloc(sizeof(vfd_settings_t)))) {

--- a/vfd/spindle.h
+++ b/vfd/spindle.h
@@ -89,5 +89,6 @@ typedef struct {
 extern vfd_settings_t vfd_config;
 
 spindle_id_t vfd_register (const vfd_spindle_ptrs_t *vfd, const char *name);
+const vfd_ptrs_t *vfd_get_active (void);
 
 #endif

--- a/vfd/spindle.h
+++ b/vfd/spindle.h
@@ -55,7 +55,9 @@ typedef enum {
     VFD_GetMaxRPM,
     VFD_GetMaxRPM50,
     VFD_GetStatus,
-    VFD_SetStatus
+    VFD_SetStatus,
+    VFD_GetMaxAmps,
+    VFD_GetAmps
 } vfd_response_t;
 
 typedef struct {


### PR DESCRIPTION
Support for spindle load reporting was added to the realtime report output in the last upstream commit.

This PR adds the necessary support code for the v1 Huanyang VFD, and a new function to retrieve the active VFD function pointers (for access from another plugin).

Load is reported as a percentage of the actual spindle amps vs maximum configured spindle amps.

```
// Example of access from another plugin
#if VFD_ENABLE
    const vfd_ptrs_t *vfd_spindle = vfd_get_active();
    if (vfd_spindle && vfd_spindle->get_load) {
        float load = vfd_spindle->get_load();
    }
#endif

```