### PR TITLE
H100: Use vfd_config.vfd_rpm_hz for hz<->rpm conversion

### DIFF
--- a/vfd/h100.c
+++ b/vfd/h100.c
@@ -84,7 +84,7 @@ static void set_rpm (float rpm, bool block)
 
     if(rpm != spindle_data.rpm_programmed) {
 
-        uint16_t freq = (uint16_t)(rpm * 0.167f); // * 10.0f / 60.0f
+        uint16_t freq = (uint16_t)(rpm * 10.0f / vfd_config.vfd_rpm_hz); // For 24000rpm/400Hz spindle: * 10.0f / 60.0f
 
         freq = min(max(freq, freq_min), freq_max);
 
@@ -189,7 +189,7 @@ static spindle_data_t *spindleGetData (spindle_data_request_t request)
 
 static float f2rpm (uint16_t f)
 {
-    return (float)f * 6.0f; // * 60.0f / 10.0f
+    return (float)f * vfd_config.vfd_rpm_hz / 10.0f; // For 24000rpm/400Hz spindle: * 60.0f / 10.0f
 }
 
 static void rx_packet (modbus_message_t *msg)

--- a/vfd/spindle.c
+++ b/vfd/spindle.c
@@ -206,7 +206,7 @@ static bool is_modvfd_selected (const setting_detail_t *setting, uint_fast16_t o
 
 #endif // SPINDLE_MODVFD
 
-#if SPINDLE_ENABLE & ((1<<SPINDLE_GS20)|(1<<SPINDLE_YL620A))
+#if SPINDLE_ENABLE & ((1<<SPINDLE_GS20)|(1<<SPINDLE_YL620A)|(1<<SPINDLE_H100))
 
 #if N_SPINDLE == 1
 
@@ -224,7 +224,7 @@ static bool is_ysgl_selected (const setting_detail_t *setting, uint_fast16_t off
 
     if(idx > 0) do {
         if(spindle_select_get_binding(vfd_spindles[--idx].id) >= 0)
-            ok = !strcmp(spindle_get_name(vfd_spindles[idx].id), "Yalang YS620") || !strcmp(spindle_get_name(vfd_spindles[idx].id), "Durapulse GS20");
+            ok = !strcmp(spindle_get_name(vfd_spindles[idx].id), "Yalang YS620") || !strcmp(spindle_get_name(vfd_spindles[idx].id), "Durapulse GS20") || !strcmp(spindle_get_name(vfd_spindles[idx].id), "H-100");
     } while(idx && !ok);
 
     return ok;
@@ -252,7 +252,7 @@ PROGMEM static const setting_detail_t vfd_settings[] = {
 #else
      { Setting_VFD_ModbusAddress, Group_VFD, "VFD spindle ModBus address", NULL, Format_Int8, "##0", NULL, "255", Setting_NonCore, &vfd_config.modbus_address, NULL, NULL },
 #endif
-#if SPINDLE_ENABLE & ((1<<SPINDLE_GS20)|(1<<SPINDLE_YL620A))
+#if SPINDLE_ENABLE & ((1<<SPINDLE_GS20)|(1<<SPINDLE_YL620A)|(1<<SPINDLE_H100))
      { Setting_VFD_RPM_Hz, Group_VFD, "RPM per Hz", "", Format_Int16, "###0", "1", "3000", Setting_NonCore, &vfd_config.vfd_rpm_hz, NULL, is_ysgl_selected },
 #endif
 #if SPINDLE_ENABLE & (1<<SPINDLE_MODVFD)
@@ -283,7 +283,7 @@ PROGMEM static const setting_descr_t vfd_settings_descr[] = {
     { Setting_VFD_ModbusAddress, "VFD ModBus address" },
 #endif
 #if SPINDLE_ENABLE & ((1<<SPINDLE_GS20)|(1<<SPINDLE_YL620A))
-    { Setting_VFD_RPM_Hz, "RPM/Hz value for GS20 and YL620A" },
+    { Setting_VFD_RPM_Hz, "RPM/Hz value for GS20, YL620A and H100" },
 #endif
 #if SPINDLE_ENABLE & (1<<SPINDLE_MODVFD)
     { Setting_VFD_10, "MODVFD Register for Run/stop" },


### PR DESCRIPTION
Changes:
- The H100 driver now uses the vfd_config.vfd_rpm_hz parameter for the hz<->rpm conversion just like YL620A/GS20

I made the change, because I own a 24000rpm/**800Hz** spindle that requires a different conversion factor than the *60* that is hardcoded in the driver. (Mine requires *30*).

---

The alternative to this change would be to load the Max RPM value / VFD_GetRPMAt50Hz, like it is done for the "Huanyang v1", but the documentation for this parameter seems weird. [Manual of the H100](https://github.com/johnobrien/printnc/blob/main/H100_VFD_Manual.pdf)

Similar to the Huanyang, the H100 has a F144 parameter. It is labelled differently in the summary and description sections:
- Summary: `Rated rotating speed of motor` (Ex. factory value per manual: 1440, but was set to **24000** when I got it)
- Description: `Motor rotating speed. It shall be set according to actual speed of the motor; displayed value is identical to this parameter and can be used as the parameter used for monitoring to facilitate the user;this set value is corresponding to to the rotating speed at 50Hz.`

The VFD_GetRPMAt50Hz probably originated from the 50Hz part in this description?

I think entering the rpm@50Hz value into F144 is *wrong*.  
My assumption is, that F144 is supposed to contain the rated/nominal/**max** rpm of the motor. And the 50Hz in the description only exists, because most industrial motors are rated for 50Hz, not 400 or 800.

I can also sort-of prove my assumption, because:
- a) my VFD already had 24000 set when I got it from Aliexpress
- b) I activated the "Operation speed" display option on the H100, which means the display now shows rpm instead of Hz. And the display shows the correct values with F144=24000.

You can activate the "Operation speed" display option with F170=2. Then on the "main" screen cycle through the display options with SHIFT(4 times: output freq -> set freq -> output current -> output voltage -> option set in F170). F180 can be used to set the default display option, btw. My VFD now always shows rpm instead of Hz :)

Anyway, I am still unsure about the proper meaning of F144 and opted to use the vfd_config.vfd_rpm_hz parameter instead.  
Another option would be to read the number of poles (F143), where 400Hz spindles usually have 2 and mine has 4. Idk.